### PR TITLE
removed functions, just as easy to access with keywords

### DIFF
--- a/src/salesforce/core.clj
+++ b/src/salesforce/core.clj
@@ -57,9 +57,6 @@
        (-> (:body resp)
            (json/decode true))))
 
-(defn token [auth] (:access_token auth))
-
-(defn instance-url [auth] (:instance_url auth))
 
 ;; HTTP request functions
 ;; ******************************************************************************


### PR DESCRIPTION
i was initially confused by the (token) function as a lot of methods take a parameter called _token_, but this is not the what this method returns.

so i figured these two functions aren't really needed as it's just as easy to use keywords to get at them.
