### PR TITLE
(with-latest-version) now uses memoized call to latest-version

### DIFF
--- a/src/salesforce/core.clj
+++ b/src/salesforce/core.clj
@@ -105,10 +105,14 @@
        (into {})
        :version))
 
+(def latest-version*
+  "Memoized latest-version, used by (with-latest-version) macro"
+  (memoize latest-version))
+
 (defonce ^{:dynamic true :private true} +version+ "")
 
 (defmacro with-latest-version [& forms]
-  `(binding [+version+ (latest-version)]
+  `(binding [+version+ (latest-version*)]
      (do ~@forms)))
 
 (defmacro with-version [v & forms]


### PR DESCRIPTION
when using (with-latest-version) the caller will most likely want to use the same latest-version throughout their session, and there's basically no chance the latest version will update during the session or even lifetime of the application (without restart).
