### PR TITLE
Fixing `so->update`

### DIFF
--- a/src/salesforce/core.clj
+++ b/src/salesforce/core.clj
@@ -197,10 +197,10 @@
    - token your api auth info"
   [sobject identifier record token]
   (let [params
-    { :form-params record
+    { :body (json/generate-string record)
       :content-type :json }]
     (request :patch
-      (format "/services/data/v%s/sobjects/Account/%s/$s" @+version+ sobject identifier) 
+      (format "/services/data/v%s/sobjects/%s/%s" @+version+ sobject identifier) 
       token params)))
 
 (defn so->delete


### PR DESCRIPTION
`:json-params` does not appear to be parsed correctly by Salesforce, however submitting it as deserialized JSON in the body does.
