### PR TITLE
compensating for salesforce sandbox cache bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ pom.xml
 *.class
 .lein*
 settings.clj
+.nrepl-port

--- a/src/salesforce/core.clj
+++ b/src/salesforce/core.clj
@@ -217,6 +217,23 @@
 (comment
   (so->delete "Account" "001i0000008Ge2OAAS" auth))
 
+(defn so->flow
+  "Invoke a flow (see: https://developer.salesforce.com/docs/atlas.en-us.salesforce_vpm_guide.meta/salesforce_vpm_guide/vpm_distribute_system_rest.htm)
+  - indentifier of flow (e.g. \"Escalate_to_Case\")
+  - inputs map (e.g. {:inputs [{\"CommentCount\" 6
+                                \"FeedItemId\" \"0D5D0000000cfMY\"}]})
+  - token to your api auth info"
+  [identifier token & [data]]
+  (let [params {:body (json/generate-string (or data {:inputs []}))
+                :content-type :json}]
+    (request :post
+      (format "/services/data/v%s/actions/custom/flow/%s" @+version+ identifier)
+      token params)))
+
+(comment
+  (so->flow "Escalate_to_Case" a {:inputs [{"CommentCount" 6
+                                            "FeedItemId" "0D5D0000000cfMY"}]}))
+
 ;; Salesforce Object Query Language
 ;; *******************************************************
 

--- a/src/salesforce/core.clj
+++ b/src/salesforce/core.clj
@@ -43,9 +43,10 @@
    - username USERNAME
    - password PASSWORD
    - security-token TOKEN
-   - sandbox? IS_SANDBOX"
-  [{:keys [client-id client-secret username password security-token sandbox?]}]
-     (let [login-host (if sandbox? "test.salesforce.com" "login.salesforce.com")
+   - sandbox? IS_SANDBOX
+   - sandbox-url URL"
+  [{:keys [client-id client-secret username password security-token sandbox? sandbox-url]}]
+     (let [login-host (if sandbox? (or sandbox-url "test.salesforce.com") "login.salesforce.com")
            auth-url (format "https://%s/services/oauth2/token" login-host)
            params {:grant_type "password"
                    :client_id client-id


### PR DESCRIPTION
I know its speculative, but its essential for us. Salesforce is occasionally preventing the use of "test.salesforce.com" in Sandbox environments because of what appears to be a caching bug in their workflow. Others are also running into it:

https://developer.salesforce.com/forums/ForumsMain?id=906F0000000AImAIAW

The resolution is simply to change the URL to "cs10.salesforce.com", or whatever has been assigned for the Sandbox.

Perhaps there's a better approach, but I feel this commit is low-impact enough...