### PR TITLE
Provide means to track API limit request info

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,8 +1,8 @@
-(defproject salesforce "1.0.1"
+(defproject com.banzai/salesforce "1.0.6"
   :description "A clojure library for accessing the salesforce api"
   :url "http://owainlewis.com"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.6.0"]
-                 [clj-http "2.0.1"]
+  :dependencies [[org.clojure/clojure "1.7.0"]
+                 [clj-http "0.7.2"]
                  [cheshire "5.1.1"]])

--- a/project.clj
+++ b/project.clj
@@ -4,5 +4,5 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.6.0"]
-                 [clj-http "0.7.2"]
+                 [clj-http "2.0.1"]
                  [cheshire "5.1.1"]])

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.banzai/salesforce "1.0.6"
+(defproject salesforce "1.0.1"
   :description "A clojure library for accessing the salesforce api"
   :url "http://owainlewis.com"
   :license {:name "Eclipse Public License"


### PR DESCRIPTION
So, the library – as is – is not particularly amenable to collecting additional data from Salesforce's REST responses – `request`, for example, returns the `:body` parameter to all the public-facing functions (e.g. `so->get`, `so->create`, etc.).

But, the response still contains other important information, such as API limit information. This may not be the best implementation, because it's stateful, but to the client user, it's dead simple:

```
(so->get ...)
```

Calling the function now returns the body of the response, as usual, but in calling it, it's also recorded the limit information from the response header to an atom: `limit-info`. The client user can retrieve the used and available API counts by calling:

```
(read-limit-info)
=> {:used 100 :available 15000}
```

Again, a little different, but simple to implement, and easy to use, given the current design of the library.