### PR TITLE
fix: pin exact Clojure CLI tools release

### DIFF
--- a/.github/workflows/dependency-freshness.yml
+++ b/.github/workflows/dependency-freshness.yml
@@ -19,7 +19,7 @@ jobs:
           java-version: 21
       - uses: DeLaGuardo/setup-clojure@4c7a6f613e5089821bb3bb2a33a3ee115578580d # 13.6.1
         with:
-          cli: 1.12.5
+          cli: 1.12.5.1654
       - name: Report outdated dependencies
         run: |
           output=$(clojure -Sdeps '{:deps {com.github.liquidz/antq {:mvn/version "2.11.1276"}}}' \


### PR DESCRIPTION
## Summary

- pin the dependency freshness workflow to the exact Clojure CLI tools release
- fix the clean-run setup failure discovered after PR #28 merged

## Verification

- confirmed `clojure/brew-install` release `1.12.5.1654` exists and is stable
- independent subagent review confirmed setup-clojure accepts the exact tag and the official installer returns HTTP 200
- GitHub CI and a manual dependency freshness run will provide hosted-runner proof

Follow-up to #28.